### PR TITLE
fix(dropdown): 'enter' key selects item from drop down

### DIFF
--- a/src/CompletionSuggestions/index.js
+++ b/src/CompletionSuggestions/index.js
@@ -210,7 +210,7 @@ export default function (addModifier, Entry, suggestionsThemeKey) {
 
     commitSelection = () => {
       this.onCompletionSelect(this.props.suggestions.get(this.state.focusedOptionIndex));
-      return true;
+      return 'handled';
     };
 
     openDropdown = () => {


### PR DESCRIPTION
Chrome doesn't work when true is returned. It needed 'handled'