### PR TITLE
Preserve trigger character in search value

### DIFF
--- a/examples/issue/components/IssueEditor.js
+++ b/examples/issue/components/IssueEditor.js
@@ -39,8 +39,9 @@ export default class IssueEditor extends React.Component {
   onChange = (editorState, cb) => this.setState({ editorState }, cb);
 
   onIssueSearchChange = ({ value }) => {
+    const searchValue = value.substring(1, value.length);
     this.setState({
-      suggestions: defaultSuggestionsFilter(value, suggestions),
+      suggestions: defaultSuggestionsFilter(searchValue, suggestions),
     });
   };
 

--- a/src/CompletionSuggestions/index.js
+++ b/src/CompletionSuggestions/index.js
@@ -148,8 +148,8 @@ export default function (addModifier, Entry, suggestionsThemeKey) {
     };
 
     onSearchChange = (editorState, selection) => {
-      const { word } = getSearchText(editorState, selection);
-      const searchValue = word.substring(1, word.length);
+      const searchText = getSearchText(editorState, selection);
+      const searchValue = searchText.word;
       if (this.lastSearchValue !== searchValue) {
         this.lastSearchValue = searchValue;
         this.props.onSearchChange({ value: searchValue });


### PR DESCRIPTION
This moves knowledge of how the trigger character relates to the search value
out of the library and into the hands of the consumer.

Motivations for this change are currently:
* multi-character triggers
* trigger characters that occur at the end of a string instead of the beginning
* otherwise wishing to not remove the trigger character from the search value

I imagine this should allow #5 to be closed without merging.