### PR TITLE
Upgrade to draft-js-plugins-editor@2.0.0-beta9

### DIFF
--- a/examples/issue/components/IssueEditor.js
+++ b/examples/issue/components/IssueEditor.js
@@ -36,7 +36,7 @@ export default class IssueEditor extends React.Component {
     };
   }
 
-  onChange = (editorState, cb) => this.setState({ editorState }, cb);
+  onChange = (editorState) => this.setState({ editorState });
 
   onIssueSearchChange = ({ value }) => {
     this.setState({

--- a/examples/issue/package.json
+++ b/examples/issue/package.json
@@ -2,7 +2,7 @@
   "name": "issue-plugin-example",
   "version": "0.0.0",
   "dependencies": {
-    "draft-js-plugins-editor": "^1.1.0",
+    "draft-js-plugins-editor": "2.0.0-beta9",
     "draft-js": "^0.9.1",
     "immutable": ">=3.7.6",
     "react": "15.1.0",


### PR DESCRIPTION
This upgrades the version of the `draft-js-plugins-editor` used in the
`IssueEditor` example.

The motivation for this is summarized in draft-js-plugins/draft-js-plugins#634