### PR TITLE
Fix "Unknown props" warning

### DIFF
--- a/src/CompletionSuggestions/index.js
+++ b/src/CompletionSuggestions/index.js
@@ -263,10 +263,20 @@ export default function (addModifier, Entry, suggestionsThemeKey) {
         return null;
       }
 
-      const { theme = {} } = this.props;
+      const {
+        onSearchChange, // eslint-disable-line no-unused-vars, no-shadow
+        suggestions, // eslint-disable-line no-unused-vars
+        ariaProps, // eslint-disable-line no-unused-vars
+        callbacks, // eslint-disable-line no-unused-vars
+        theme = {},
+        store, // eslint-disable-line no-unused-vars
+        entityMutability, // eslint-disable-line no-unused-vars
+        positionSuggestions, // eslint-disable-line no-unused-vars
+        ...elementProps,
+      } = this.props;
       return (
         <div
-          {...this.props}
+          {...elementProps}
           className={ theme[suggestionsThemeKey] }
           role="listbox"
           id={ `completions-list-${this.key}` }


### PR DESCRIPTION
This should close #3.

It uses the same method as `draft-js-plugins` currently uses to remove unknown props.

https://github.com/draft-js-plugins/draft-js-plugins/blob/ac5ec4b288824f8acbf46e7d230eabb6e4e5fc90/draft-js-mention-plugin/src/MentionSuggestions/index.js#L299-L314