### PR TITLE
Fix a regression with `getWordAt`

### DIFF
--- a/src/utils/getWordAt.js
+++ b/src/utils/getWordAt.js
@@ -4,7 +4,7 @@ const getWordAt = (string, position) => {
   const pos = Number(position) >>> 0;
 
   // Search for the word's beginning and end.
-  const left = str.slice(0, pos).search(/\S+$/);
+  const left = str.slice(0, pos + 1).search(/\S+$/);
   const right = str.slice(pos).search(/\s/);
 
   // The last word in the string is a special case.


### PR DESCRIPTION
This was incorrectly introduced in 96ae7cce145233843d871358bf63b6f69c506c0d.

I had trouble making the tests work in this repo but confirmed the bug by changing the equivalent file in `draft-js-plugins` and running the tests there.